### PR TITLE
feat: add configurable SMART scope enforcement and role-based filtering

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -212,7 +212,7 @@ export const config = {
     get patientScopedResources(): string[] {
       const defaults = ['Observation', 'Condition', 'Procedure', 'MedicationRequest', 'MedicationStatement', 'DiagnosticReport', 'Encounter', 'AllergyIntolerance', 'ImagingStudy', 'CarePlan', 'Consent']
       const env = process.env.PATIENT_SCOPED_RESOURCES?.split(',').map(s => s.trim()).filter(Boolean)
-      return env || defaults
+      return env && env.length > 0 ? env : defaults
     },
   },
 

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -191,6 +191,31 @@ export const config = {
     }
   },
 
+  accessControl: {
+    // SMART scope enforcement — validates token scopes against requested FHIR resources
+    get scopeEnforcement(): 'enforce' | 'audit-only' | 'disabled' {
+      const mode = process.env.SCOPE_ENFORCEMENT_MODE || 'disabled'
+      if (mode === 'enforce' || mode === 'audit-only' || mode === 'disabled') return mode
+      return 'disabled'
+    },
+    // Role-based filtering using fhirUser claim (e.g. generalPractitioner-based isolation)
+    get roleBasedFiltering(): 'enforce' | 'audit-only' | 'disabled' {
+      const mode = process.env.ROLE_BASED_FILTERING_MODE || 'disabled'
+      if (mode === 'enforce' || mode === 'audit-only' || mode === 'disabled') return mode
+      return 'disabled'
+    },
+    // Block write operations for non-admin users (users with fhirUser claim)
+    get readOnlyForUsers() {
+      return process.env.READ_ONLY_FOR_USERS === 'true'
+    },
+    // Clinical resource types subject to patient-scoped filtering
+    get patientScopedResources(): string[] {
+      const defaults = ['Observation', 'Condition', 'Procedure', 'MedicationRequest', 'MedicationStatement', 'DiagnosticReport', 'Encounter', 'AllergyIntolerance', 'ImagingStudy', 'CarePlan', 'Consent']
+      const env = process.env.PATIENT_SCOPED_RESOURCES?.split(',').map(s => s.trim()).filter(Boolean)
+      return env || defaults
+    },
+  },
+
   kisi: {
     // Kisi Access Control integration
     get apiKey() {

--- a/backend/src/lib/smart-access-control.ts
+++ b/backend/src/lib/smart-access-control.ts
@@ -1,0 +1,467 @@
+/**
+ * SMART on FHIR Access Control
+ *
+ * Three independent, opt-in access control features for the FHIR proxy:
+ *
+ * 1. **SMART Scope Enforcement** — validates token scopes against requested resources
+ *    (supports SMART v1 `read`/`write` and v2 `cruds` character formats)
+ *
+ * 2. **Role-Based Data Isolation** — Practitioners see only their assigned patients;
+ *    patients see only their own data (via `fhirUser` claim)
+ *
+ * 3. **Write Blocking** — optionally blocks write operations for non-admin users
+ *
+ * All features default to `disabled` and don't affect existing consent-based access control.
+ */
+
+import { config } from '../config'
+import { logger } from './logger'
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface AccessControlContext {
+  /** Raw token payload from JWT validation */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tokenPayload: Record<string, any>
+  /** The FHIR resource path (e.g. "Patient/123", "Observation") */
+  resourcePath: string
+  /** HTTP method */
+  method: string
+  /** Upstream FHIR server base URL */
+  serverUrl: string
+  /** Server identifier (for mTLS config lookup) */
+  serverId: string
+  /** Server name (for logging) */
+  serverName: string
+  /** Original Authorization header value */
+  authHeader: string
+  /** Function to perform upstream FHIR fetch (mTLS-aware) */
+  upstreamFetch: (url: string, init?: RequestInit) => Promise<Response>
+}
+
+export interface AccessControlResult {
+  /** Whether to allow the request to proceed */
+  allowed: boolean
+  /** HTTP status code if denied */
+  status?: number
+  /** Error response body if denied */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  body?: Record<string, any>
+  /** Modified query string (role-based filtering may inject search params) */
+  modifiedQueryString?: string
+}
+
+// ── fhirUser normalization ───────────────────────────────────────────────────
+
+/**
+ * Normalize a fhirUser claim to a relative reference (e.g. "Patient/123").
+ * Handles both relative references and full URLs per SMART spec.
+ */
+function normalizeFhirUser(fhirUser: string): string {
+  // Already relative
+  if (fhirUser.startsWith('Patient/') || fhirUser.startsWith('Practitioner/') || fhirUser.startsWith('Person/') || fhirUser.startsWith('RelatedPerson/')) {
+    return fhirUser
+  }
+  // Full URL — extract the resource type and ID from the path
+  const match = fhirUser.match(/(Patient|Practitioner|Person|RelatedPerson)\/([a-zA-Z0-9\-.]+)/)
+  if (match) {
+    return `${match[1]}/${match[2]}`
+  }
+  return fhirUser
+}
+
+// ── SMART Scope Enforcement ──────────────────────────────────────────────────
+
+/** Map HTTP methods to SMART v2 permission characters */
+const METHOD_TO_V2_CHAR: Record<string, string> = {
+  GET: 'r',
+  POST: 'c',
+  PUT: 'u',
+  PATCH: 'u',
+  DELETE: 'd',
+}
+
+/**
+ * Check whether token scopes grant the requested access.
+ * Supports SMART v1 (`read`/`write`/`*`) and v2 (`cruds` character) formats.
+ */
+function checkSmartScopes(
+  tokenScopes: string[],
+  resourceType: string,
+  method: string,
+): boolean {
+  const requiredChar = METHOD_TO_V2_CHAR[method]
+  const isRead = method === 'GET'
+  const isWrite = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)
+
+  return tokenScopes.some((scope) => {
+    // Match SMART scope pattern: context/resource.permissions
+    const match = scope.match(/^(patient|user|system)\/([\w*]+)\.([\w*]+)$/)
+    if (!match) return false
+    const [, , scopeResource, scopePermission] = match
+
+    // Check resource type match
+    if (scopeResource !== '*' && scopeResource !== resourceType) return false
+
+    // Check permission match
+    if (scopePermission === '*') return true
+
+    // SMART v1 format
+    if (isRead && scopePermission === 'read') return true
+    if (isWrite && scopePermission === 'write') return true
+
+    // SMART v2 format — exact character matching (not .includes())
+    // v2 permissions are a subset of "cruds" characters
+    if (scopePermission.length <= 5 && /^[cruds]+$/.test(scopePermission)) {
+      if (requiredChar && scopePermission.includes(requiredChar)) return true
+      // 's' = search, equivalent to read for GET requests
+      if (isRead && scopePermission.includes('s')) return true
+    }
+
+    return false
+  })
+}
+
+export function enforceScopeAccess(ctx: AccessControlContext): AccessControlResult {
+  if (config.accessControl.scopeEnforcement === 'disabled') {
+    return { allowed: true }
+  }
+
+  const tokenScopes = ((ctx.tokenPayload.scope as string) || '').split(' ').filter(Boolean)
+  const resourceType = ctx.resourcePath.split(/[/?]/)[0]
+
+  // Skip scope checks for metadata endpoint and empty resource types
+  if (!resourceType || resourceType === 'metadata') {
+    return { allowed: true }
+  }
+
+  const hasAccess = checkSmartScopes(tokenScopes, resourceType, ctx.method)
+
+  if (!hasAccess) {
+    logger.fhir.warn('SMART scope check failed', {
+      resourceType,
+      method: ctx.method,
+      scopes: tokenScopes.join(' '),
+      fhirUser: ctx.tokenPayload.fhirUser,
+      server: ctx.serverName,
+      mode: config.accessControl.scopeEnforcement,
+    })
+
+    if (config.accessControl.scopeEnforcement === 'enforce') {
+      return {
+        allowed: false,
+        status: 403,
+        body: {
+          error: 'insufficient_scope',
+          message: `Token does not grant ${ctx.method} access to ${resourceType}. Required scope: patient/${resourceType}.read or user/${resourceType}.read (or equivalent).`,
+        },
+      }
+    }
+    // audit-only: log but allow
+  }
+
+  return { allowed: true }
+}
+
+// ── Write Blocking ───────────────────────────────────────────────────────────
+
+export function enforceWriteBlocking(ctx: AccessControlContext): AccessControlResult {
+  if (
+    !config.accessControl.readOnlyForUsers ||
+    !['POST', 'PUT', 'PATCH', 'DELETE'].includes(ctx.method) ||
+    !ctx.tokenPayload.fhirUser
+  ) {
+    return { allowed: true }
+  }
+
+  logger.fhir.warn('Write operation blocked for non-admin user', {
+    fhirUser: ctx.tokenPayload.fhirUser,
+    method: ctx.method,
+    resourcePath: ctx.resourcePath,
+    server: ctx.serverName,
+  })
+
+  return {
+    allowed: false,
+    status: 403,
+    body: {
+      error: 'access_denied',
+      message: 'Write operations are not permitted for this user role',
+    },
+  }
+}
+
+// ── Role-Based Filtering ─────────────────────────────────────────────────────
+
+/**
+ * Perform an upstream FHIR fetch with proper auth/mTLS, checking response status.
+ * Returns the parsed JSON bundle or null on failure.
+ */
+async function upstreamFhirQuery(
+  ctx: AccessControlContext,
+  url: string,
+  description: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<Record<string, any> | null> {
+  try {
+    const headers: Record<string, string> = { Accept: 'application/fhir+json' }
+    if (ctx.authHeader) {
+      headers.Authorization = ctx.authHeader
+    }
+
+    const resp = await ctx.upstreamFetch(url, { method: 'GET', headers })
+
+    if (!resp.ok) {
+      logger.fhir.warn(`Upstream ${description} failed`, {
+        server: ctx.serverName,
+        status: resp.status,
+        statusText: resp.statusText,
+      })
+      return null
+    }
+
+    return await resp.json()
+  } catch (err) {
+    logger.fhir.error(`Upstream ${description} error`, {
+      server: ctx.serverName,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return null
+  }
+}
+
+export async function enforceRoleBasedFiltering(
+  ctx: AccessControlContext,
+  queryString: string,
+): Promise<AccessControlResult> {
+  if (config.accessControl.roleBasedFiltering === 'disabled') {
+    return { allowed: true, modifiedQueryString: queryString }
+  }
+
+  const rawFhirUser = ctx.tokenPayload.fhirUser as string | undefined
+  if (!rawFhirUser) {
+    return { allowed: true, modifiedQueryString: queryString }
+  }
+
+  const fhirUser = normalizeFhirUser(rawFhirUser)
+  const resourceType = ctx.resourcePath.split(/[/?]/)[0]
+  const patientScopedResources = config.accessControl.patientScopedResources
+  const isEnforce = config.accessControl.roleBasedFiltering === 'enforce'
+
+  if (fhirUser.startsWith('Practitioner/')) {
+    return enforcePractitionerFiltering(ctx, queryString, fhirUser, resourceType, patientScopedResources, isEnforce)
+  }
+
+  if (fhirUser.startsWith('Patient/')) {
+    return enforcePatientFiltering(ctx, queryString, fhirUser, resourceType, patientScopedResources, isEnforce)
+  }
+
+  return { allowed: true, modifiedQueryString: queryString }
+}
+
+async function enforcePractitionerFiltering(
+  ctx: AccessControlContext,
+  queryString: string,
+  fhirUser: string,
+  resourceType: string,
+  patientScopedResources: string[],
+  isEnforce: boolean,
+): Promise<AccessControlResult> {
+  // Patient search: inject general-practitioner filter
+  if (ctx.method === 'GET' && /^Patient(\?|$)/.test(ctx.resourcePath)) {
+    const sep = queryString ? '&' : '?'
+    queryString += `${sep}general-practitioner=${encodeURIComponent(fhirUser)}`
+    return { allowed: true, modifiedQueryString: queryString }
+  }
+
+  // Direct Patient read by ID: verify assignment
+  const patientDirectMatch = ctx.resourcePath.match(/^Patient\/([^/]+)/)
+  if (ctx.method === 'GET' && patientDirectMatch) {
+    const patientId = patientDirectMatch[1]
+    if (patientId !== '$' && !patientId.startsWith('$')) {
+      const checkUrl = `${ctx.serverUrl}/Patient?_id=${encodeURIComponent(patientId)}&general-practitioner=${encodeURIComponent(fhirUser)}&_format=json`
+      const bundle = await upstreamFhirQuery(ctx, checkUrl, 'patient assignment check')
+
+      if (bundle === null) {
+        // Upstream failed — fail open in audit-only, fail closed in enforce
+        if (isEnforce) {
+          return {
+            allowed: false,
+            status: 502,
+            body: { error: 'upstream_error', message: 'Failed to validate patient assignment on upstream FHIR server' },
+          }
+        }
+      } else if (!bundle.entry?.length) {
+        const msg = `Patient ${patientId} is not assigned to ${fhirUser}`
+        logger.fhir.warn('Practitioner access denied to patient', { fhirUser, patientId, server: ctx.serverName })
+        if (isEnforce) {
+          return { allowed: false, status: 403, body: { error: 'access_denied', message: msg } }
+        }
+      }
+    }
+    return { allowed: true, modifiedQueryString: queryString }
+  }
+
+  // Patient-scoped resource search: inject patient filter
+  if (ctx.method === 'GET' && patientScopedResources.includes(resourceType) && !ctx.resourcePath.includes('/')) {
+    const patientsUrl = `${ctx.serverUrl}/Patient?general-practitioner=${encodeURIComponent(fhirUser)}&_elements=id&_format=json`
+    const bundle = await upstreamFhirQuery(ctx, patientsUrl, 'practitioner patient list lookup')
+
+    if (bundle === null) {
+      if (isEnforce) {
+        return {
+          allowed: false,
+          status: 502,
+          body: { error: 'upstream_error', message: 'Failed to resolve practitioner patient assignments on upstream FHIR server' },
+        }
+      }
+      // audit-only: proceed without filtering
+      return { allowed: true, modifiedQueryString: queryString }
+    }
+
+    const patientIds = (bundle.entry || []).map((e: { resource: { id: string } }) => e.resource.id)
+
+    if (patientIds.length === 0) {
+      return {
+        allowed: true,
+        modifiedQueryString: queryString,
+        status: 200,
+        body: { resourceType: 'Bundle', type: 'searchset', total: 0, entry: [] },
+      }
+    }
+
+    const sep = queryString ? '&' : '?'
+    queryString += `${sep}patient=${patientIds.map((id: string) => `Patient/${id}`).join(',')}`
+    return { allowed: true, modifiedQueryString: queryString }
+  }
+
+  // Patient-scoped resource direct read by ID: verify patient assignment
+  if (ctx.method === 'GET' && patientScopedResources.includes(resourceType) && ctx.resourcePath.includes('/')) {
+    const idMatch = ctx.resourcePath.match(/^[^/]+\/([^/?]+)/)
+    const resourceId = idMatch?.[1]
+    if (resourceId && resourceId !== '$' && !resourceId.startsWith('$')) {
+      // First get assigned patients
+      const patientsUrl = `${ctx.serverUrl}/Patient?general-practitioner=${encodeURIComponent(fhirUser)}&_elements=id&_format=json`
+      const patientsBundle = await upstreamFhirQuery(ctx, patientsUrl, 'practitioner patient list for direct read')
+
+      if (patientsBundle === null) {
+        if (isEnforce) {
+          return {
+            allowed: false,
+            status: 502,
+            body: { error: 'upstream_error', message: 'Failed to validate practitioner assignment on upstream FHIR server' },
+          }
+        }
+      } else {
+        const patientIds = (patientsBundle.entry || []).map((e: { resource: { id: string } }) => e.resource.id)
+        if (patientIds.length === 0) {
+          logger.fhir.warn('Practitioner has no assigned patients, denying direct read', {
+            fhirUser, resourceType, resourceId, server: ctx.serverName,
+          })
+          if (isEnforce) {
+            return { allowed: false, status: 403, body: { error: 'access_denied', message: `Practitioner ${fhirUser} has no assigned patients` } }
+          }
+        } else {
+          // Verify the resource belongs to an assigned patient
+          const patientParam = patientIds.map((id: string) => `Patient/${id}`).join(',')
+          const checkUrl = `${ctx.serverUrl}/${resourceType}?_id=${encodeURIComponent(resourceId)}&patient=${encodeURIComponent(patientParam)}&_format=json`
+          const checkBundle = await upstreamFhirQuery(ctx, checkUrl, 'resource patient assignment check')
+
+          if (checkBundle === null) {
+            if (isEnforce) {
+              return {
+                allowed: false,
+                status: 502,
+                body: { error: 'upstream_error', message: 'Failed to validate resource patient assignment on upstream FHIR server' },
+              }
+            }
+          } else if (!checkBundle.entry?.length) {
+            logger.fhir.warn('Practitioner access denied to patient-scoped resource', {
+              fhirUser, resourceType, resourceId, server: ctx.serverName,
+            })
+            if (isEnforce) {
+              return {
+                allowed: false,
+                status: 403,
+                body: { error: 'access_denied', message: `${resourceType}/${resourceId} is not associated with a patient assigned to ${fhirUser}` },
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return { allowed: true, modifiedQueryString: queryString }
+}
+
+async function enforcePatientFiltering(
+  ctx: AccessControlContext,
+  queryString: string,
+  fhirUser: string,
+  resourceType: string,
+  patientScopedResources: string[],
+  isEnforce: boolean,
+): Promise<AccessControlResult> {
+  const ownPatientId = fhirUser.split('/')[1]
+
+  // Patient search: restrict to own record
+  if (ctx.method === 'GET' && /^Patient(\?|$)/.test(ctx.resourcePath)) {
+    const sep = queryString ? '&' : '?'
+    queryString += `${sep}_id=${encodeURIComponent(ownPatientId)}`
+    return { allowed: true, modifiedQueryString: queryString }
+  }
+
+  // Direct Patient read by ID: deny if different patient
+  const patientDirectMatch = ctx.resourcePath.match(/^Patient\/([^/]+)/)
+  if (ctx.method === 'GET' && patientDirectMatch) {
+    const patientId = patientDirectMatch[1]
+    if (patientId !== '$' && !patientId.startsWith('$') && patientId !== ownPatientId) {
+      logger.fhir.warn('Patient access denied to other patient', { fhirUser, requestedPatient: patientId, server: ctx.serverName })
+      if (isEnforce) {
+        return { allowed: false, status: 403, body: { error: 'access_denied', message: 'You can only access your own patient record' } }
+      }
+    }
+    return { allowed: true, modifiedQueryString: queryString }
+  }
+
+  // Patient-scoped resource search: filter to own data
+  if (ctx.method === 'GET' && patientScopedResources.includes(resourceType) && !ctx.resourcePath.includes('/')) {
+    const sep = queryString ? '&' : '?'
+    queryString += `${sep}patient=Patient/${encodeURIComponent(ownPatientId)}`
+    return { allowed: true, modifiedQueryString: queryString }
+  }
+
+  // Patient-scoped resource direct read by ID: verify ownership
+  if (ctx.method === 'GET' && patientScopedResources.includes(resourceType) && ctx.resourcePath.includes('/')) {
+    const idMatch = ctx.resourcePath.match(/^[^/]+\/([^/?]+)/)
+    const resourceId = idMatch?.[1]
+    if (resourceId && resourceId !== '$' && !resourceId.startsWith('$')) {
+      const checkUrl = `${ctx.serverUrl}/${resourceType}?_id=${encodeURIComponent(resourceId)}&patient=Patient/${encodeURIComponent(ownPatientId)}&_format=json`
+      const checkBundle = await upstreamFhirQuery(ctx, checkUrl, 'patient resource ownership check')
+
+      if (checkBundle === null) {
+        if (isEnforce) {
+          return {
+            allowed: false,
+            status: 502,
+            body: { error: 'upstream_error', message: 'Failed to validate resource ownership on upstream FHIR server' },
+          }
+        }
+      } else if (!checkBundle.entry?.length) {
+        logger.fhir.warn('Patient access denied to unowned resource', {
+          fhirUser, resourceType, resourceId, server: ctx.serverName,
+        })
+        if (isEnforce) {
+          return {
+            allowed: false,
+            status: 403,
+            body: { error: 'access_denied', message: `${resourceType}/${resourceId} does not belong to your patient record` },
+          }
+        }
+      }
+    }
+  }
+
+  return { allowed: true, modifiedQueryString: queryString }
+}

--- a/backend/src/routes/fhir.ts
+++ b/backend/src/routes/fhir.ts
@@ -74,17 +74,17 @@ async function proxyFHIR({ params, request, set }: any) {
     const resourcePath = parts.slice(3).join('/')
     let queryString = requestUrl.search
 
+    // Resolve mTLS config once per request (used by both access control and proxy fetch)
+    const mtlsConfig = await getMtlsConfig(serverInfo.identifier)
+    const serverFetch = async (url: string, init?: RequestInit) => {
+      const useMtls = mtlsConfig?.enabled === true && url.startsWith('https://')
+      return useMtls
+        ? fetchWithMtls(url, { ...init, serverId: serverInfo.identifier })
+        : fetch(url, init)
+    }
+
     // 3–5) SMART access control (scope enforcement, write blocking, role-based filtering)
     if (tokenPayload) {
-      // Build mTLS-aware upstream fetch for access control queries
-      const mtlsCfg = await getMtlsConfig(serverInfo.identifier)
-      const acUpstreamFetch = async (url: string, init?: RequestInit) => {
-        const useUpstreamMtls = mtlsCfg?.enabled === true && url.startsWith('https://')
-        return useUpstreamMtls
-          ? fetchWithMtls(url, { ...init, serverId: serverInfo.identifier })
-          : fetch(url, init)
-      }
-
       const acCtx: AccessControlContext = {
         tokenPayload,
         resourcePath,
@@ -93,7 +93,7 @@ async function proxyFHIR({ params, request, set }: any) {
         serverId: serverInfo.identifier,
         serverName: params.server_name,
         authHeader,
-        upstreamFetch: acUpstreamFetch,
+        upstreamFetch: serverFetch,
       }
 
       // 3) SMART scope enforcement
@@ -135,7 +135,6 @@ async function proxyFHIR({ params, request, set }: any) {
     }
 
     // Check if mTLS is configured for this server
-    const mtlsConfig = await getMtlsConfig(serverInfo.identifier)
     const useMtls = mtlsConfig?.enabled === true && target.startsWith('https://')
 
     // Use appropriate fetch method based on mTLS configuration

--- a/backend/src/routes/fhir.ts
+++ b/backend/src/routes/fhir.ts
@@ -9,6 +9,7 @@ import { smartConfigService } from '../lib/smart-config'
 import { logger } from '../lib/logger'
 import { fetchWithMtls, getMtlsConfig } from './fhir-servers'
 import { checkConsentWithIal, getConsentConfig, getIalConfig } from '../lib/consent'
+import { enforceScopeAccess, enforceWriteBlocking, enforceRoleBasedFiltering, type AccessControlContext } from '../lib/smart-access-control'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function proxyFHIR({ params, request, set }: any) {
@@ -73,130 +74,50 @@ async function proxyFHIR({ params, request, set }: any) {
     const resourcePath = parts.slice(3).join('/')
     let queryString = requestUrl.search
 
-    // 3) SMART scope enforcement (only if enabled via SCOPE_ENFORCEMENT_MODE)
-    if (tokenPayload && config.accessControl.scopeEnforcement !== 'disabled') {
-      const tokenScopes = ((tokenPayload.scope as string) || '').split(' ').filter(Boolean)
-      const resourceType = resourcePath.split(/[/?]/)[0]
-
-      if (resourceType && resourceType !== 'metadata') {
-        const method = request.method as string
-        const methodToV2Char: Record<string, string> = { GET: 'r', POST: 'c', PUT: 'u', PATCH: 'u', DELETE: 'd' }
-        const requiredChar = methodToV2Char[method]
-        const isRead = method === 'GET'
-        const isWrite = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)
-
-        const hasAccess = tokenScopes.some((scope) => {
-          const match = scope.match(/^(patient|user|system)\/([\w*]+)\.([\w*]+)$/)
-          if (!match) return false
-          const [, , scopeResource, scopePermission] = match
-          if (scopeResource !== '*' && scopeResource !== resourceType) return false
-          if (scopePermission === '*' || scopePermission === 'cruds') return true
-          if (isRead && (scopePermission === 'read' || scopePermission === 'rs' || scopePermission.includes('r'))) return true
-          if (isWrite && (scopePermission === 'write' || (requiredChar && scopePermission.includes(requiredChar)))) return true
-          return false
-        })
-
-        if (!hasAccess) {
-          logger.fhir.warn('SMART scope check failed', {
-            resourceType, method, scopes: tokenScopes.join(' '),
-            fhirUser: tokenPayload.fhirUser, server: params.server_name,
-          })
-          if (config.accessControl.scopeEnforcement === 'enforce') {
-            set.status = 403
-            return {
-              error: 'insufficient_scope',
-              message: `Token does not grant ${method} access to ${resourceType}. Required scope: patient/${resourceType}.read or user/${resourceType}.read (or equivalent).`,
-            }
-          }
-        }
+    // 3–5) SMART access control (scope enforcement, write blocking, role-based filtering)
+    if (tokenPayload) {
+      // Build mTLS-aware upstream fetch for access control queries
+      const mtlsCfg = await getMtlsConfig(serverInfo.identifier)
+      const acUpstreamFetch = async (url: string, init?: RequestInit) => {
+        const useUpstreamMtls = mtlsCfg?.enabled === true && url.startsWith('https://')
+        return useUpstreamMtls
+          ? fetchWithMtls(url, { ...init, serverId: serverInfo.identifier })
+          : fetch(url, init)
       }
-    }
 
-    // 4) Write operation restrictions (only if READ_ONLY_FOR_USERS is enabled)
-    if (
-      config.accessControl.readOnlyForUsers &&
-      ['POST', 'PUT', 'PATCH', 'DELETE'].includes(request.method) &&
-      tokenPayload?.fhirUser
-    ) {
-      logger.fhir.warn('Write operation blocked for non-admin user', {
-        fhirUser: tokenPayload.fhirUser, method: request.method,
-        resourcePath, server: params.server_name,
-      })
-      set.status = 403
-      return { error: 'access_denied', message: 'Write operations are not permitted for this user role' }
-    }
-
-    // 5) Role-based FHIR access control (only if enabled via ROLE_BASED_FILTERING_MODE)
-    if (tokenPayload && config.accessControl.roleBasedFiltering !== 'disabled') {
-      const fhirUser = tokenPayload.fhirUser as string | undefined
-      const resourceType = resourcePath.split(/[/?]/)[0]
-      const patientScopedResources = config.accessControl.patientScopedResources
-
-      if (fhirUser?.startsWith('Practitioner/')) {
-        // Practitioner: only access patients assigned via generalPractitioner
-        if (request.method === 'GET' && /^Patient(\?|$)/.test(resourcePath)) {
-          const sep = queryString ? '&' : '?'
-          queryString += `${sep}general-practitioner=${encodeURIComponent(fhirUser)}`
-        }
-
-        const patientDirectMatch = resourcePath.match(/^Patient\/([^/]+)/)
-        if (request.method === 'GET' && patientDirectMatch) {
-          const patientId = patientDirectMatch[1]
-          if (patientId !== '$' && !patientId.startsWith('$')) {
-            const checkUrl = `${serverUrl}/Patient?_id=${encodeURIComponent(patientId)}&general-practitioner=${encodeURIComponent(fhirUser)}&_format=json`
-            const checkResp = await fetch(checkUrl, { method: 'GET', headers: { Accept: 'application/fhir+json' } })
-            const checkBundle = await checkResp.json()
-            if (!checkBundle.entry?.length) {
-              const msg = `Patient ${patientId} is not assigned to ${fhirUser}`
-              logger.fhir.warn('Practitioner access denied to patient', { fhirUser, patientId, server: params.server_name })
-              if (config.accessControl.roleBasedFiltering === 'enforce') {
-                set.status = 403
-                return { error: 'access_denied', message: msg }
-              }
-            }
-          }
-        }
-
-        if (request.method === 'GET' && patientScopedResources.includes(resourceType) && !resourcePath.includes('/')) {
-          const patientsUrl = `${serverUrl}/Patient?general-practitioner=${encodeURIComponent(fhirUser)}&_elements=id&_format=json`
-          const patientsResp = await fetch(patientsUrl, { method: 'GET', headers: { Accept: 'application/fhir+json' } })
-          const patientsBundle = await patientsResp.json()
-          const patientIds = (patientsBundle.entry || []).map((e: { resource: { id: string } }) => e.resource.id)
-
-          if (patientIds.length === 0) {
-            set.status = 200
-            return { resourceType: 'Bundle', type: 'searchset', total: 0, entry: [] }
-          }
-
-          const sep = queryString ? '&' : '?'
-          queryString += `${sep}patient=${patientIds.map((id: string) => `Patient/${id}`).join(',')}`
-        }
-      } else if (fhirUser?.startsWith('Patient/')) {
-        // Patient: only access own data
-        const ownPatientId = fhirUser.split('/')[1]
-
-        if (request.method === 'GET' && /^Patient(\?|$)/.test(resourcePath)) {
-          const sep = queryString ? '&' : '?'
-          queryString += `${sep}_id=${encodeURIComponent(ownPatientId)}`
-        }
-
-        const patientDirectMatch = resourcePath.match(/^Patient\/([^/]+)/)
-        if (request.method === 'GET' && patientDirectMatch) {
-          const patientId = patientDirectMatch[1]
-          if (patientId !== '$' && !patientId.startsWith('$') && patientId !== ownPatientId) {
-            logger.fhir.warn('Patient access denied to other patient', { fhirUser, requestedPatient: patientId, server: params.server_name })
-            if (config.accessControl.roleBasedFiltering === 'enforce') {
-              set.status = 403
-              return { error: 'access_denied', message: 'You can only access your own patient record' }
-            }
-          }
-        }
-
-        if (request.method === 'GET' && patientScopedResources.includes(resourceType) && !resourcePath.includes('/')) {
-          const sep = queryString ? '&' : '?'
-          queryString += `${sep}patient=Patient/${encodeURIComponent(ownPatientId)}`
-        }
+      const acCtx: AccessControlContext = {
+        tokenPayload,
+        resourcePath,
+        method: request.method,
+        serverUrl,
+        serverId: serverInfo.identifier,
+        serverName: params.server_name,
+        authHeader,
+        upstreamFetch: acUpstreamFetch,
       }
+
+      // 3) SMART scope enforcement
+      const scopeResult = enforceScopeAccess(acCtx)
+      if (!scopeResult.allowed) {
+        set.status = scopeResult.status
+        return scopeResult.body
+      }
+
+      // 4) Write blocking
+      const writeResult = enforceWriteBlocking(acCtx)
+      if (!writeResult.allowed) {
+        set.status = writeResult.status
+        return writeResult.body
+      }
+
+      // 5) Role-based filtering
+      const roleResult = await enforceRoleBasedFiltering(acCtx, queryString)
+      if (!roleResult.allowed) {
+        set.status = roleResult.status
+        // Check for early return (e.g. empty bundle for practitioner with no patients)
+        return roleResult.body
+      }
+      queryString = roleResult.modifiedQueryString ?? queryString
     }
 
     const target = `${serverUrl}${resourcePath ? `/${resourcePath}` : ''}${queryString}`

--- a/backend/src/routes/fhir.ts
+++ b/backend/src/routes/fhir.ts
@@ -71,7 +71,134 @@ async function proxyFHIR({ params, request, set }: any) {
     const requestUrl = new URL(request.url)
     const parts = requestUrl.pathname.split('/').filter(Boolean)
     const resourcePath = parts.slice(3).join('/')
-    const queryString = requestUrl.search
+    let queryString = requestUrl.search
+
+    // 3) SMART scope enforcement (only if enabled via SCOPE_ENFORCEMENT_MODE)
+    if (tokenPayload && config.accessControl.scopeEnforcement !== 'disabled') {
+      const tokenScopes = ((tokenPayload.scope as string) || '').split(' ').filter(Boolean)
+      const resourceType = resourcePath.split(/[/?]/)[0]
+
+      if (resourceType && resourceType !== 'metadata') {
+        const method = request.method as string
+        const methodToV2Char: Record<string, string> = { GET: 'r', POST: 'c', PUT: 'u', PATCH: 'u', DELETE: 'd' }
+        const requiredChar = methodToV2Char[method]
+        const isRead = method === 'GET'
+        const isWrite = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)
+
+        const hasAccess = tokenScopes.some((scope) => {
+          const match = scope.match(/^(patient|user|system)\/([\w*]+)\.([\w*]+)$/)
+          if (!match) return false
+          const [, , scopeResource, scopePermission] = match
+          if (scopeResource !== '*' && scopeResource !== resourceType) return false
+          if (scopePermission === '*' || scopePermission === 'cruds') return true
+          if (isRead && (scopePermission === 'read' || scopePermission === 'rs' || scopePermission.includes('r'))) return true
+          if (isWrite && (scopePermission === 'write' || (requiredChar && scopePermission.includes(requiredChar)))) return true
+          return false
+        })
+
+        if (!hasAccess) {
+          logger.fhir.warn('SMART scope check failed', {
+            resourceType, method, scopes: tokenScopes.join(' '),
+            fhirUser: tokenPayload.fhirUser, server: params.server_name,
+          })
+          if (config.accessControl.scopeEnforcement === 'enforce') {
+            set.status = 403
+            return {
+              error: 'insufficient_scope',
+              message: `Token does not grant ${method} access to ${resourceType}. Required scope: patient/${resourceType}.read or user/${resourceType}.read (or equivalent).`,
+            }
+          }
+        }
+      }
+    }
+
+    // 4) Write operation restrictions (only if READ_ONLY_FOR_USERS is enabled)
+    if (
+      config.accessControl.readOnlyForUsers &&
+      ['POST', 'PUT', 'PATCH', 'DELETE'].includes(request.method) &&
+      tokenPayload?.fhirUser
+    ) {
+      logger.fhir.warn('Write operation blocked for non-admin user', {
+        fhirUser: tokenPayload.fhirUser, method: request.method,
+        resourcePath, server: params.server_name,
+      })
+      set.status = 403
+      return { error: 'access_denied', message: 'Write operations are not permitted for this user role' }
+    }
+
+    // 5) Role-based FHIR access control (only if enabled via ROLE_BASED_FILTERING_MODE)
+    if (tokenPayload && config.accessControl.roleBasedFiltering !== 'disabled') {
+      const fhirUser = tokenPayload.fhirUser as string | undefined
+      const resourceType = resourcePath.split(/[/?]/)[0]
+      const patientScopedResources = config.accessControl.patientScopedResources
+
+      if (fhirUser?.startsWith('Practitioner/')) {
+        // Practitioner: only access patients assigned via generalPractitioner
+        if (request.method === 'GET' && /^Patient(\?|$)/.test(resourcePath)) {
+          const sep = queryString ? '&' : '?'
+          queryString += `${sep}general-practitioner=${encodeURIComponent(fhirUser)}`
+        }
+
+        const patientDirectMatch = resourcePath.match(/^Patient\/([^/]+)/)
+        if (request.method === 'GET' && patientDirectMatch) {
+          const patientId = patientDirectMatch[1]
+          if (patientId !== '$' && !patientId.startsWith('$')) {
+            const checkUrl = `${serverUrl}/Patient?_id=${encodeURIComponent(patientId)}&general-practitioner=${encodeURIComponent(fhirUser)}&_format=json`
+            const checkResp = await fetch(checkUrl, { method: 'GET', headers: { Accept: 'application/fhir+json' } })
+            const checkBundle = await checkResp.json()
+            if (!checkBundle.entry?.length) {
+              const msg = `Patient ${patientId} is not assigned to ${fhirUser}`
+              logger.fhir.warn('Practitioner access denied to patient', { fhirUser, patientId, server: params.server_name })
+              if (config.accessControl.roleBasedFiltering === 'enforce') {
+                set.status = 403
+                return { error: 'access_denied', message: msg }
+              }
+            }
+          }
+        }
+
+        if (request.method === 'GET' && patientScopedResources.includes(resourceType) && !resourcePath.includes('/')) {
+          const patientsUrl = `${serverUrl}/Patient?general-practitioner=${encodeURIComponent(fhirUser)}&_elements=id&_format=json`
+          const patientsResp = await fetch(patientsUrl, { method: 'GET', headers: { Accept: 'application/fhir+json' } })
+          const patientsBundle = await patientsResp.json()
+          const patientIds = (patientsBundle.entry || []).map((e: { resource: { id: string } }) => e.resource.id)
+
+          if (patientIds.length === 0) {
+            set.status = 200
+            return { resourceType: 'Bundle', type: 'searchset', total: 0, entry: [] }
+          }
+
+          const sep = queryString ? '&' : '?'
+          queryString += `${sep}patient=${patientIds.map((id: string) => `Patient/${id}`).join(',')}`
+        }
+      } else if (fhirUser?.startsWith('Patient/')) {
+        // Patient: only access own data
+        const ownPatientId = fhirUser.split('/')[1]
+
+        if (request.method === 'GET' && /^Patient(\?|$)/.test(resourcePath)) {
+          const sep = queryString ? '&' : '?'
+          queryString += `${sep}_id=${encodeURIComponent(ownPatientId)}`
+        }
+
+        const patientDirectMatch = resourcePath.match(/^Patient\/([^/]+)/)
+        if (request.method === 'GET' && patientDirectMatch) {
+          const patientId = patientDirectMatch[1]
+          if (patientId !== '$' && !patientId.startsWith('$') && patientId !== ownPatientId) {
+            logger.fhir.warn('Patient access denied to other patient', { fhirUser, requestedPatient: patientId, server: params.server_name })
+            if (config.accessControl.roleBasedFiltering === 'enforce') {
+              set.status = 403
+              return { error: 'access_denied', message: 'You can only access your own patient record' }
+            }
+          }
+        }
+
+        if (request.method === 'GET' && patientScopedResources.includes(resourceType) && !resourcePath.includes('/')) {
+          const sep = queryString ? '&' : '?'
+          queryString += `${sep}patient=Patient/${encodeURIComponent(ownPatientId)}`
+        }
+      }
+    }
+
     const target = `${serverUrl}${resourcePath ? `/${resourcePath}` : ''}${queryString}`
 
     const headers = new Headers()


### PR DESCRIPTION
Adds three optional access control features to the FHIR proxy, all disabled by default.

**SMART Scope Enforcement** — Validates token scopes against requested resources (supports v1 and v2 formats)
**Role-Based Data Isolation** — Practitioners see only their assigned patients; patients see only their own data
**Write Blocking** — Optionally blocks write operations for non-admin users

Configuration:

SCOPE_ENFORCEMENT_MODE = enforce / audit-only / disabled (default: disabled)
ROLE_BASED_FILTERING_MODE = enforce / audit-only / disabled (default: disabled)
READ_ONLY_FOR_USERS = true / false (default: false)
PATIENT_SCOPED_RESOURCES = comma-separated list (default: Observation, Condition, etc.)

Example for a read-only dashboard:

SCOPE_ENFORCEMENT_MODE=enforce
ROLE_BASED_FILTERING_MODE=enforce
READ_ONLY_FOR_USERS=true

All features are independent, opt-in, and don't affect existing consent-based access control.

Signed-off-by: Hamed Mishian <hamedmishian@gmail.com>

I agree to the Contributor License Agreement as outlined in CONTRIBUTING.md