### PR TITLE
refactor(ui): source Max Health brand from public-npm `brandc`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
     },
     "backend": {
       "name": "proxy-smart-backend",
-      "version": "0.2.13-beta.202607221329.f4ae079fb",
+      "version": "0.2.13-beta.202607221520.e50fd77ec",
       "dependencies": {
         "@ai-sdk/openai": "^4.0.16",
         "@elysiajs/cors": "^1.4.2",
@@ -75,7 +75,7 @@
     },
     "config/eslint": {
       "name": "@proxy-smart/eslint-config",
-      "version": "0.2.13-beta.202607221329.f4ae079fb",
+      "version": "0.2.13-beta.202607221520.e50fd77ec",
       "dependencies": {
         "@eslint/js": "^10.0.1",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -86,7 +86,7 @@
     },
     "deploy/infra": {
       "name": "proxy-smart-infra",
-      "version": "0.2.13-beta.202607221329.f4ae079fb",
+      "version": "0.2.13-beta.202607221520.e50fd77ec",
       "dependencies": {
         "aws-cdk-lib": "^2.261.0",
         "constructs": "^10.7.0",
@@ -104,7 +104,7 @@
     },
     "frontend/smart-dicom-template": {
       "name": "smart-dicom-template",
-      "version": "0.2.13-beta.202607221329.f4ae079fb",
+      "version": "0.2.13-beta.202607221520.e50fd77ec",
       "dependencies": {
         "@babelfhir-ts/dicomweb": "^0.1.3",
         "@cornerstonejs/core": "^5.6.7",
@@ -144,9 +144,8 @@
     },
     "frontend/ui": {
       "name": "proxy-smart-ui",
-      "version": "0.2.13-beta.202607221329.f4ae079fb",
+      "version": "0.2.13-beta.202607221520.e50fd77ec",
       "dependencies": {
-        "@max-network/css": "^0.1.1",
         "@proxy-smart/shared-ui": "github:Max-Health-Inc/shared-ui",
         "@radix-ui/react-avatar": "^1.2.2",
         "@radix-ui/react-dialog": "^1.1.19",
@@ -155,6 +154,7 @@
         "@radix-ui/react-slot": "^1.3.0",
         "@tailwindcss/vite": "^4.3.3",
         "@types/fhir": "^0.0.44",
+        "brandc": "^0.2.0",
         "class-variance-authority": "^0.7.1",
         "crypto-js": "^4.2.0",
         "date-fns": "^4.3.0",
@@ -203,7 +203,7 @@
     },
     "packages/app-store": {
       "name": "@proxy-smart/app-store",
-      "version": "0.2.13-beta.202607221329.f4ae079fb",
+      "version": "0.2.13-beta.202607221520.e50fd77ec",
       "devDependencies": {
         "@types/node": "^26.1.1",
         "typescript": "6.0.3",
@@ -211,7 +211,7 @@
     },
     "packages/auth": {
       "name": "@proxy-smart/auth",
-      "version": "0.2.13-beta.202607221329.f4ae079fb",
+      "version": "0.2.13-beta.202607221520.e50fd77ec",
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.10",
         "jsonwebtoken": "^9.0.3",
@@ -223,7 +223,7 @@
     },
     "packages/elysia-mcp": {
       "name": "@max-health-inc/elysia-mcp",
-      "version": "0.2.13-beta.202607221329.f4ae079fb",
+      "version": "0.2.13-beta.202607221520.e50fd77ec",
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@sinclair/typebox": "^0.34.52",
@@ -240,7 +240,7 @@
     },
     "packages/patient-picker": {
       "name": "proxy-smart-patient-picker",
-      "version": "0.2.13-beta.202607221329.f4ae079fb",
+      "version": "0.2.13-beta.202607221520.e50fd77ec",
       "dependencies": {
         "@fontsource-variable/geist": "^5.3.0",
         "@proxy-smart/shared-ui": "github:Max-Health-Inc/shared-ui",
@@ -637,8 +637,6 @@
     "@loxjs/url-join": ["@loxjs/url-join@1.0.2", "", {}, "sha512-BqzK8+iHqxUbPRZV6NBum63CJzE0G6vGG3o+4dqeIzbywdoTg+xHJbksYDkk1P1w3Gj64U20Rgp44HHciLbRzg=="],
 
     "@max-health-inc/elysia-mcp": ["@max-health-inc/elysia-mcp@workspace:packages/elysia-mcp"],
-
-    "@max-network/css": ["@max-network/css@0.1.1", "https://npm.pkg.github.com/download/@max-network/css/0.1.1/3328c535833119b5013a655c9c3b28eb99df72e2", {}, "sha512-oHTxu4uioCtDsOwWgoGVxMNwtkJeV4gDg5WXq85EviiPubQisMGunEdHVdDk4JO0wq+tExCnR02o1mqfMS7oOg=="],
 
     "@microsoft/kiota-abstractions": ["@microsoft/kiota-abstractions@1.0.0-preview.103", "", { "dependencies": { "@opentelemetry/api": "^1.7.0", "@std-uritemplate/std-uritemplate": "^2.0.0", "tinyduration": "^3.3.0", "tslib": "^2.6.2" } }, "sha512-om7nKH8nWyEAQ0lgbIdKdrkmznhkdDJdliCnAIo31X/hlUah1aBzvfUx+pbyp67Q040yLK+2J6P7AnvGSoN/qQ=="],
 
@@ -1245,6 +1243,8 @@
     "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "brandc": ["brandc@0.2.0", "", {}, "sha512-Fe/ncCfBNxQS/0GJLLh2W6s3QgE/yisngohNPqLHJuH65pDTP9CMm9+g/Pd8N4hL9F0+/75G9go1Z76Eca7p4g=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
@@ -3202,7 +3202,7 @@
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
-    "proxy-smart-ui/@proxy-smart/shared-ui": ["@max-health-inc/shared-ui@github:Max-Health-Inc/shared-ui#fdcccf0", { "dependencies": { "@max-network/css": "^0.1.1", "@radix-ui/react-slot": "^1.2.4", "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "lucide-react": "^1.14.0", "radix-ui": "^1.4.3", "sonner": "^2.0.7", "tailwind-merge": "^3.5.0" }, "peerDependencies": { "i18next": "^26.0.0", "i18next-browser-languagedetector": "^8.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "react-i18next": "^17.0.0" }, "optionalPeers": ["i18next", "i18next-browser-languagedetector", "react-i18next"] }, "Max-Health-Inc-shared-ui-fdcccf0", "sha512-tYPDFk2zMSwmdH9fncdYq9Cc7ROrlVD9k4WplWgYTQA1jgFn5G5jmqciyn2yyzhq4hVybUR2M5REtYhbtbdqKg=="],
+    "proxy-smart-ui/@proxy-smart/shared-ui": ["@max-health-inc/shared-ui@github:Max-Health-Inc/shared-ui#5cc5ace", { "dependencies": { "@radix-ui/react-slot": "^1.2.4", "brandc": "^0.2.0", "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "lucide-react": "^1.14.0", "radix-ui": "^1.4.3", "sonner": "^2.0.7", "tailwind-merge": "^3.5.0" }, "peerDependencies": { "i18next": "^26.0.0", "i18next-browser-languagedetector": "^8.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "react-i18next": "^17.0.0" }, "optionalPeers": ["i18next", "i18next-browser-languagedetector", "react-i18next"] }, "Max-Health-Inc-shared-ui-5cc5ace", "sha512-ppLOOSQPPeyEAhl2PUs6vimw7yupvav05PJrq48Gj6eGtXaziUbWFtCHaYcM10ZdSGhkV9C06OIsk1YWNzDMdg=="],
 
     "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
     },
     "backend": {
       "name": "proxy-smart-backend",
-      "version": "0.2.13-alpha.202607191930.ad4938422",
+      "version": "0.2.13-beta.202607221329.f4ae079fb",
       "dependencies": {
         "@ai-sdk/openai": "^4.0.16",
         "@elysiajs/cors": "^1.4.2",
@@ -75,7 +75,7 @@
     },
     "config/eslint": {
       "name": "@proxy-smart/eslint-config",
-      "version": "0.2.13-alpha.202607191930.ad4938422",
+      "version": "0.2.13-beta.202607221329.f4ae079fb",
       "dependencies": {
         "@eslint/js": "^10.0.1",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -86,7 +86,7 @@
     },
     "deploy/infra": {
       "name": "proxy-smart-infra",
-      "version": "0.2.13-alpha.202607191930.ad4938422",
+      "version": "0.2.13-beta.202607221329.f4ae079fb",
       "dependencies": {
         "aws-cdk-lib": "^2.261.0",
         "constructs": "^10.7.0",
@@ -104,7 +104,7 @@
     },
     "frontend/smart-dicom-template": {
       "name": "smart-dicom-template",
-      "version": "0.2.13-alpha.202607191930.ad4938422",
+      "version": "0.2.13-beta.202607221329.f4ae079fb",
       "dependencies": {
         "@babelfhir-ts/dicomweb": "^0.1.3",
         "@cornerstonejs/core": "^5.6.7",
@@ -144,8 +144,9 @@
     },
     "frontend/ui": {
       "name": "proxy-smart-ui",
-      "version": "0.2.13-alpha.202607191930.ad4938422",
+      "version": "0.2.13-beta.202607221329.f4ae079fb",
       "dependencies": {
+        "@max-network/css": "^0.1.1",
         "@proxy-smart/shared-ui": "github:Max-Health-Inc/shared-ui",
         "@radix-ui/react-avatar": "^1.2.2",
         "@radix-ui/react-dialog": "^1.1.19",
@@ -202,7 +203,7 @@
     },
     "packages/app-store": {
       "name": "@proxy-smart/app-store",
-      "version": "0.2.13-alpha.202607191930.ad4938422",
+      "version": "0.2.13-beta.202607221329.f4ae079fb",
       "devDependencies": {
         "@types/node": "^26.1.1",
         "typescript": "6.0.3",
@@ -210,7 +211,7 @@
     },
     "packages/auth": {
       "name": "@proxy-smart/auth",
-      "version": "0.2.13-alpha.202607191930.ad4938422",
+      "version": "0.2.13-beta.202607221329.f4ae079fb",
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.10",
         "jsonwebtoken": "^9.0.3",
@@ -222,7 +223,7 @@
     },
     "packages/elysia-mcp": {
       "name": "@max-health-inc/elysia-mcp",
-      "version": "0.2.13-alpha.202607191930.ad4938422",
+      "version": "0.2.13-beta.202607221329.f4ae079fb",
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@sinclair/typebox": "^0.34.52",
@@ -239,7 +240,7 @@
     },
     "packages/patient-picker": {
       "name": "proxy-smart-patient-picker",
-      "version": "0.2.13-alpha.202607191930.ad4938422",
+      "version": "0.2.13-beta.202607221329.f4ae079fb",
       "dependencies": {
         "@fontsource-variable/geist": "^5.3.0",
         "@proxy-smart/shared-ui": "github:Max-Health-Inc/shared-ui",
@@ -636,6 +637,8 @@
     "@loxjs/url-join": ["@loxjs/url-join@1.0.2", "", {}, "sha512-BqzK8+iHqxUbPRZV6NBum63CJzE0G6vGG3o+4dqeIzbywdoTg+xHJbksYDkk1P1w3Gj64U20Rgp44HHciLbRzg=="],
 
     "@max-health-inc/elysia-mcp": ["@max-health-inc/elysia-mcp@workspace:packages/elysia-mcp"],
+
+    "@max-network/css": ["@max-network/css@0.1.1", "https://npm.pkg.github.com/download/@max-network/css/0.1.1/3328c535833119b5013a655c9c3b28eb99df72e2", {}, "sha512-oHTxu4uioCtDsOwWgoGVxMNwtkJeV4gDg5WXq85EviiPubQisMGunEdHVdDk4JO0wq+tExCnR02o1mqfMS7oOg=="],
 
     "@microsoft/kiota-abstractions": ["@microsoft/kiota-abstractions@1.0.0-preview.103", "", { "dependencies": { "@opentelemetry/api": "^1.7.0", "@std-uritemplate/std-uritemplate": "^2.0.0", "tinyduration": "^3.3.0", "tslib": "^2.6.2" } }, "sha512-om7nKH8nWyEAQ0lgbIdKdrkmznhkdDJdliCnAIo31X/hlUah1aBzvfUx+pbyp67Q040yLK+2J6P7AnvGSoN/qQ=="],
 
@@ -3198,6 +3201,8 @@
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "proxy-smart-ui/@proxy-smart/shared-ui": ["@max-health-inc/shared-ui@github:Max-Health-Inc/shared-ui#fdcccf0", { "dependencies": { "@max-network/css": "^0.1.1", "@radix-ui/react-slot": "^1.2.4", "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "lucide-react": "^1.14.0", "radix-ui": "^1.4.3", "sonner": "^2.0.7", "tailwind-merge": "^3.5.0" }, "peerDependencies": { "i18next": "^26.0.0", "i18next-browser-languagedetector": "^8.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "react-i18next": "^17.0.0" }, "optionalPeers": ["i18next", "i18next-browser-languagedetector", "react-i18next"] }, "Max-Health-Inc-shared-ui-fdcccf0", "sha512-tYPDFk2zMSwmdH9fncdYq9Cc7ROrlVD9k4WplWgYTQA1jgFn5G5jmqciyn2yyzhq4hVybUR2M5REtYhbtbdqKg=="],
 
     "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -13,12 +13,8 @@ minimumReleaseAge = 0 # Allow all packages regardless of age
 [install.scopes]
 # Resolve @max-health-inc packages from GitHub Packages
 "@max-health-inc" = "https://npm.pkg.github.com"
-# The Max Network design-language contract (@max-network/css) — single source of
-# the Max Health brand tokens, pulled in by @max-health-inc/shared-ui and the
-# admin UI. Private GitHub Packages; auth via env (never a committed token):
-#   locally  ->  NODE_AUTH_TOKEN="$(gh auth token)" bun install
-#   in CI    ->  NODE_AUTH_TOKEN set to a token with read:packages
-"@max-network" = { url = "https://npm.pkg.github.com/", token = "$NODE_AUTH_TOKEN" }
+# NOTE: the brand-token contract is now the public-npm package `brandc` (renamed
+# from @max-network/css), so no private-registry scope/token is needed for it.
 
 # Security scanner (Socket.dev)
 # [install.security]

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -13,6 +13,12 @@ minimumReleaseAge = 0 # Allow all packages regardless of age
 [install.scopes]
 # Resolve @max-health-inc packages from GitHub Packages
 "@max-health-inc" = "https://npm.pkg.github.com"
+# The Max Network design-language contract (@max-network/css) — single source of
+# the Max Health brand tokens, pulled in by @max-health-inc/shared-ui and the
+# admin UI. Private GitHub Packages; auth via env (never a committed token):
+#   locally  ->  NODE_AUTH_TOKEN="$(gh auth token)" bun install
+#   in CI    ->  NODE_AUTH_TOKEN set to a token with read:packages
+"@max-network" = { url = "https://npm.pkg.github.com/", token = "$NODE_AUTH_TOKEN" }
 
 # Security scanner (Socket.dev)
 # [install.security]

--- a/config/eslint/package.json
+++ b/config/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/eslint-config",
-  "version": "0.2.13-beta.202607221329.f4ae079fb",
+  "version": "0.2.13-beta.202607221520.e50fd77ec",
   "private": true,
   "type": "module",
   "exports": {

--- a/frontend/smart-dicom-template/package.json
+++ b/frontend/smart-dicom-template/package.json
@@ -3,7 +3,7 @@
   "displayName": "SMART DICOM Algorithm Template",
   "description": "Starter kit for building SMART on FHIR imaging algorithm apps. Clone, implement your algorithm in src/algorithm.ts, and deploy as a SMART app.",
   "private": true,
-  "version": "0.2.13-beta.202607221329.f4ae079fb",
+  "version": "0.2.13-beta.202607221520.e50fd77ec",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5180",

--- a/frontend/ui/package.json
+++ b/frontend/ui/package.json
@@ -3,7 +3,7 @@
   "displayName": "Proxy Smart Admin UI",
   "description": "A web-based administration interface for managing healthcare applications and resources via Proxy Smart.",
   "private": true,
-  "version": "0.2.13-beta.202607221329.f4ae079fb",
+  "version": "0.2.13-beta.202607221520.e50fd77ec",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/ui/package.json
+++ b/frontend/ui/package.json
@@ -17,6 +17,7 @@
     "test:coverage": "vitest --coverage"
   },
   "dependencies": {
+    "@max-network/css": "^0.1.1",
     "@proxy-smart/shared-ui": "github:Max-Health-Inc/shared-ui",
     "@radix-ui/react-avatar": "^1.2.2",
     "@radix-ui/react-dialog": "^1.1.19",

--- a/frontend/ui/package.json
+++ b/frontend/ui/package.json
@@ -17,7 +17,7 @@
     "test:coverage": "vitest --coverage"
   },
   "dependencies": {
-    "@max-network/css": "^0.1.1",
+    "brandc": "^0.2.0",
     "@proxy-smart/shared-ui": "github:Max-Health-Inc/shared-ui",
     "@radix-ui/react-avatar": "^1.2.2",
     "@radix-ui/react-dialog": "^1.1.19",

--- a/frontend/ui/src/index.css
+++ b/frontend/ui/src/index.css
@@ -1,16 +1,16 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 /*
- * Max Health brand tokens — SINGLE SOURCE of truth in @max-network/css (the org
- * design-language contract), pulled in via @max-health-inc/shared-ui.
+ * Max Health brand tokens — SINGLE SOURCE of truth in the `brandc` design-language
+ * contract (public npm), also consumed by @max-health-inc/shared-ui.
  *   theme.css    ships the token VALUES (:root + dark via light-dark(), radius 0,
  *                flat/no-shadow, the Max Health emerald --maxhealth).
  *   tailwind.css maps them to Tailwind utilities by reference (bg-primary,
  *                text-maxhealth, bg-success, …) so runtime dark-switching works.
- * Rebrand or tweak a colour upstream in @max-network/css, never here.
+ * Rebrand or tweak a colour upstream in `brandc`, never here.
  */
-@import "@max-network/css/theme.css";
-@import "@max-network/css/tailwind.css";
+@import "brandc/theme.css";
+@import "brandc/tailwind.css";
 @plugin "@tailwindcss/typography";
 @source "../node_modules/@proxy-smart/shared-ui/src";
 

--- a/frontend/ui/src/index.css
+++ b/frontend/ui/src/index.css
@@ -1,20 +1,20 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+/*
+ * Max Health brand tokens — SINGLE SOURCE of truth in @max-network/css (the org
+ * design-language contract), pulled in via @max-health-inc/shared-ui.
+ *   theme.css    ships the token VALUES (:root + dark via light-dark(), radius 0,
+ *                flat/no-shadow, the Max Health emerald --maxhealth).
+ *   tailwind.css maps them to Tailwind utilities by reference (bg-primary,
+ *                text-maxhealth, bg-success, …) so runtime dark-switching works.
+ * Rebrand or tweak a colour upstream in @max-network/css, never here.
+ */
+@import "@max-network/css/theme.css";
+@import "@max-network/css/tailwind.css";
 @plugin "@tailwindcss/typography";
 @source "../node_modules/@proxy-smart/shared-ui/src";
 
 @custom-variant dark (&:is(.dark *));
-
-/*
- * Max Health Inc. Design System
- * 
- * Foundational design patterns from maxhealth.tech:
- * - High contrast monochromatic palette
- * - Emerald accent color (#00d294 / oklch(0.75 0.17 162))
- * - Geist font family (variable weight)
- * - Subtle borders (5-10% opacity white/black)
- * - Clean, minimal aesthetic
- */
 
 /* Geist Sans - Variable Font */
 @font-face {
@@ -34,172 +34,41 @@
   font-display: swap;
 }
 
-/* Geist font family */
-@theme {
+/*
+ * App-specific overrides layered on top of the contract:
+ *   - Point the font vars at the self-hosted Geist faces (the contract references
+ *     a generic "Geist Variable" / mono stack; we ship the actual woff2 above).
+ *   - Keep the flat aesthetic on the larger radius steps the contract does not
+ *     zero (it only flattens through --radius-lg).
+ */
+@theme inline {
   --font-sans: "Geist Sans", ui-sans-serif, system-ui, sans-serif;
   --font-mono: "Geist Mono", ui-monospace, monospace;
+  --radius-xl: 0rem;
+  --radius-2xl: 0rem;
+  --radius-3xl: 0rem;
+  --radius-4xl: 0rem;
 }
 
-/* Apply Geist font globally */
-html, body {
-  font-family: "Geist Sans", ui-sans-serif, system-ui, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-code, pre, kbd, samp {
-  font-family: "Geist Mono", ui-monospace, monospace;
-}
-
-@theme inline {
-  --radius-sm: 0px;
-  --radius-md: 0px;
-  --radius-lg: 0px;
-  --radius-xl: 0px;
-  --radius-2xl: 0px;
-  --radius-3xl: 0px;
-  --radius-4xl: 0px;
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-  --color-popover: var(--popover);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-secondary: var(--secondary);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-accent: var(--accent);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-destructive: var(--destructive);
-  --color-border: var(--border);
-  --color-input: var(--input);
-  --color-ring: var(--ring);
-  --color-chart-1: var(--chart-1);
-  --color-chart-2: var(--chart-2);
-  --color-chart-3: var(--chart-3);
-  --color-chart-4: var(--chart-4);
-  --color-chart-5: var(--chart-5);
-  --color-sidebar: var(--sidebar);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
-  /* Max Health brand color */
-  --color-maxhealth: var(--maxhealth);
-  --color-maxhealth-foreground: var(--maxhealth-foreground);
-}
-
-/* 
- * Light Mode - Max Health Style
- * Clean white background with near-black text
- * Matches inverted maxhealth.tech aesthetic
+/*
+ * Chart palette: keep a multi-hue healthcare palette (distinguishable series)
+ * rather than the contract's monochrome blue ramp. This is a data-visualisation
+ * decision local to the admin UI, not a brand change. Drop this block to defer
+ * fully to the contract.
  */
 :root {
-  --radius: 0;
-  /* Core colors - crisp white/black for high contrast */
-  --background: oklch(0.995 0 0);
-  --foreground: oklch(0.09 0 0);
-  /* Card - slight off-white for layering */
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.09 0 0);
-  /* Popover - pure white with shadow for depth */
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.09 0 0);
-  /* Primary - near black, matching maxhealth.tech text */
-  --primary: oklch(0.15 0 0);
-  --primary-foreground: oklch(0.99 0 0);
-  /* Secondary - light gray for subtle backgrounds */
-  --secondary: oklch(0.965 0 0);
-  --secondary-foreground: oklch(0.15 0 0);
-  /* Muted - for disabled/subtle elements */
-  --muted: oklch(0.955 0 0);
-  --muted-foreground: oklch(0.45 0 0);
-  /* Accent - subtle gray, not competing with brand */
-  --accent: oklch(0.96 0 0);
-  --accent-foreground: oklch(0.15 0 0);
-  /* Destructive - warm red */
-  --destructive: oklch(0.55 0.22 25);
-  /* Borders - very subtle like maxhealth.tech border-white/5 inverted */
-  --border: oklch(0 0 0 / 8%);
-  --input: oklch(0 0 0 / 10%);
-  --ring: oklch(0.45 0 0);
-  /* Max Health brand emerald - #00d294 */
-  --maxhealth: oklch(0.75 0.17 162);
-  --maxhealth-foreground: oklch(0.09 0 0);
-  /* Charts - healthcare-appropriate palette */
   --chart-1: oklch(0.75 0.17 162);  /* Emerald - primary brand */
   --chart-2: oklch(0.65 0.15 250);  /* Blue - trust/medical */
   --chart-3: oklch(0.70 0.18 145);  /* Teal - health */
   --chart-4: oklch(0.75 0.12 85);   /* Amber - warning/attention */
   --chart-5: oklch(0.60 0.20 300);  /* Purple - secondary */
-  /* Sidebar - slightly darker for visual hierarchy */
-  --sidebar: oklch(0.98 0 0);
-  --sidebar-foreground: oklch(0.09 0 0);
-  --sidebar-primary: oklch(0.15 0 0);
-  --sidebar-primary-foreground: oklch(0.99 0 0);
-  --sidebar-accent: oklch(0.96 0 0);
-  --sidebar-accent-foreground: oklch(0.15 0 0);
-  --sidebar-border: oklch(0 0 0 / 6%);
-  --sidebar-ring: oklch(0.45 0 0);
 }
-
-/* 
- * Dark Mode - Max Health Style  
- * Based directly on maxhealth.tech
- * Pure black background, white text, emerald accents
- */
 .dark {
-  /* Core colors - pure black like maxhealth.tech bg-black */
-  --background: oklch(0 0 0);
-  --foreground: oklch(0.99 0 0);
-  /* Card - slightly elevated dark surface */
-  --card: oklch(0.12 0 0);
-  --card-foreground: oklch(0.99 0 0);
-  /* Popover - matching card for consistency */
-  --popover: oklch(0.12 0 0);
-  --popover-foreground: oklch(0.99 0 0);
-  /* Primary - white on dark, high contrast */
-  --primary: oklch(0.99 0 0);
-  --primary-foreground: oklch(0.09 0 0);
-  /* Secondary - dark gray for subtle backgrounds */
-  --secondary: oklch(0.15 0 0);
-  --secondary-foreground: oklch(0.95 0 0);
-  /* Muted - for disabled/subtle elements */
-  --muted: oklch(0.18 0 0);
-  --muted-foreground: oklch(0.60 0 0);
-  /* Accent - matching secondary */
-  --accent: oklch(0.15 0 0);
-  --accent-foreground: oklch(0.95 0 0);
-  /* Destructive - bright red for visibility on dark */
-  --destructive: oklch(0.65 0.22 22);
-  /* Borders - white/5% like maxhealth.tech border-white/5 */
-  --border: oklch(1 0 0 / 5%);
-  --input: oklch(1 0 0 / 8%);
-  --ring: oklch(0.55 0 0);
-  /* Max Health brand emerald - slightly brighter for dark mode */
-  --maxhealth: oklch(0.78 0.17 162);
-  --maxhealth-foreground: oklch(0.09 0 0);
-  /* Charts - vibrant for dark backgrounds */
-  --chart-1: oklch(0.78 0.17 162);  /* Emerald - primary brand */
-  --chart-2: oklch(0.70 0.18 250);  /* Blue */
-  --chart-3: oklch(0.75 0.18 145);  /* Teal */
-  --chart-4: oklch(0.80 0.15 85);   /* Amber */
-  --chart-5: oklch(0.70 0.22 300);  /* Purple */
-  /* Sidebar - slightly elevated from pure black */
-  --sidebar: oklch(0.08 0 0);
-  --sidebar-foreground: oklch(0.99 0 0);
-  --sidebar-primary: oklch(0.78 0.17 162); /* Brand emerald */
-  --sidebar-primary-foreground: oklch(0.09 0 0);
-  --sidebar-accent: oklch(0.15 0 0);
-  --sidebar-accent-foreground: oklch(0.95 0 0);
-  --sidebar-border: oklch(1 0 0 / 5%);
-  --sidebar-ring: oklch(0.55 0 0);
+  --chart-1: oklch(0.78 0.17 162);
+  --chart-2: oklch(0.70 0.18 250);
+  --chart-3: oklch(0.75 0.18 145);
+  --chart-4: oklch(0.80 0.15 85);
+  --chart-5: oklch(0.70 0.22 300);
 }
 
 @layer base {
@@ -219,7 +88,7 @@ code, pre, kbd, samp {
   code, pre, kbd {
     font-family: "Geist Mono", ui-monospace, monospace;
   }
-  
+
   /* Selection colors matching maxhealth.tech selection:bg-white selection:text-black */
   ::selection {
     background: oklch(0.15 0 0);
@@ -229,127 +98,127 @@ code, pre, kbd, samp {
     background: oklch(0.99 0 0);
     color: oklch(0.09 0 0);
   }
-  
+
   /* Custom scrollbar styles - minimal like maxhealth.tech */
   ::-webkit-scrollbar {
     width: 8px;
     height: 8px;
   }
-  
+
   ::-webkit-scrollbar-track {
     background: transparent;
   }
-  
+
   ::-webkit-scrollbar-thumb {
     background: oklch(0 0 0 / 15%);
     border-radius: 8px;
   }
-  
+
   ::-webkit-scrollbar-thumb:hover {
     background: oklch(0 0 0 / 25%);
   }
-  
+
   ::-webkit-scrollbar-corner {
     background: transparent;
   }
-  
+
   /* Dark mode scrollbar - subtle white on black */
   .dark ::-webkit-scrollbar-track {
     background: transparent;
   }
-  
+
   .dark ::-webkit-scrollbar-thumb {
     background: oklch(1 0 0 / 15%);
   }
-  
+
   .dark ::-webkit-scrollbar-thumb:hover {
     background: oklch(1 0 0 / 25%);
   }
-  
+
   .dark ::-webkit-scrollbar-corner {
     background: transparent;
   }
-  
+
   /* Main page scrollbar - slightly wider */
   html::-webkit-scrollbar,
   body::-webkit-scrollbar {
     width: 10px;
   }
-  
+
   html::-webkit-scrollbar-track,
   body::-webkit-scrollbar-track {
     background: var(--background);
   }
-  
+
   html::-webkit-scrollbar-thumb,
   body::-webkit-scrollbar-thumb {
     background: oklch(0 0 0 / 12%);
     border-radius: 6px;
     border: 2px solid var(--background);
   }
-  
+
   html::-webkit-scrollbar-thumb:hover,
   body::-webkit-scrollbar-thumb:hover {
     background: oklch(0 0 0 / 20%);
   }
-  
+
   /* Dark mode main page scrollbar */
   .dark html::-webkit-scrollbar-track,
   .dark body::-webkit-scrollbar-track {
     background: oklch(0 0 0);
   }
-  
+
   .dark html::-webkit-scrollbar-thumb,
   .dark body::-webkit-scrollbar-thumb {
     background: oklch(1 0 0 / 12%);
     border: 2px solid oklch(0 0 0);
   }
-  
+
   .dark html::-webkit-scrollbar-thumb:hover,
   .dark body::-webkit-scrollbar-thumb:hover {
     background: oklch(1 0 0 / 20%);
   }
-  
+
   /* Firefox scrollbar - minimal */
   * {
     scrollbar-width: thin;
     scrollbar-color: oklch(0 0 0 / 15%) transparent;
   }
-  
+
   .dark * {
     scrollbar-color: oklch(1 0 0 / 15%) transparent;
   }
-  
+
   /* Firefox main page scrollbar */
   html,
   body {
     scrollbar-width: thin;
     scrollbar-color: oklch(0 0 0 / 15%) var(--background);
   }
-  
+
   .dark html,
   .dark body {
     scrollbar-color: oklch(1 0 0 / 15%) oklch(0 0 0);
   }
-  
+
   /* Mantine Paper component overrides for dark mode */
   .dark .mantine-Paper-root {
     background-color: var(--card) !important;
     border-color: var(--border) !important;
     color: var(--card-foreground) !important;
   }
-  
+
   /* Specific Panel styling overrides */
   .dark .m_1b7284a3 {
     background-color: var(--card) !important;
     border-color: var(--border) !important;
   }
-  
+
   /* Ensure all nested elements in Panel inherit correct colors */
   .dark .mantine-Paper-root * {
     color: inherit;
   }
-  
+
   /* Global select dropdown styling for theme awareness */
   select {
     background-color: var(--background);
@@ -367,19 +236,19 @@ code, pre, kbd, samp {
     background-size: 1.5em 1.5em;
     padding-right: 2.5rem;
   }
-  
+
   select:focus {
     outline: none;
     border-color: oklch(var(--color-ring));
     box-shadow: 0 0 0 2px oklch(var(--color-ring) / 0.2);
   }
-  
+
   select option {
     background-color: oklch(var(--color-popover)) !important;
     color: oklch(var(--color-popover-foreground)) !important;
     padding: 0.5rem;
   }
-  
+
   /* Dark mode specific styling */
   .dark select {
     background-color: oklch(var(--color-input));
@@ -387,24 +256,24 @@ code, pre, kbd, samp {
     border-color: oklch(var(--color-border));
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%239ca3af' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
   }
-  
+
   .dark select option {
     background-color: oklch(var(--color-popover)) !important;
     color: oklch(var(--color-popover-foreground)) !important;
   }
-  
+
   /* Force light text in dark mode options */
   .dark select option {
     color: oklch(0.985 0 0) !important; /* Force light text */
     background-color: oklch(0.205 0 0) !important; /* Dark background */
   }
-  
+
   /* Alternative approach: Use contrasting colors directly */
   html.dark select option {
     color: white !important;
     background-color: rgb(39, 39, 42) !important;
   }
-  
+
   /* Global input styling for theme awareness */
   input[type="text"],
   input[type="email"],
@@ -423,7 +292,7 @@ code, pre, kbd, samp {
     line-height: 1.25rem;
     transition: all 0.2s ease-in-out;
   }
-  
+
   input[type="text"]:focus,
   input[type="email"]:focus,
   input[type="password"]:focus,
@@ -436,7 +305,7 @@ code, pre, kbd, samp {
     border-color: oklch(var(--color-ring));
     box-shadow: 0 0 0 2px oklch(var(--color-ring) / 0.2);
   }
-  
+
   /* Dark mode specific input styling */
   .dark input[type="text"],
   .dark input[type="email"],
@@ -450,20 +319,20 @@ code, pre, kbd, samp {
     color: oklch(var(--color-foreground));
     border-color: oklch(var(--color-border));
   }
-  
+
   /* Placeholder text styling */
   input::placeholder,
   textarea::placeholder {
     color: oklch(var(--color-muted-foreground));
     opacity: 1;
   }
-  
+
   .dark input::placeholder,
   .dark textarea::placeholder {
     color: oklch(var(--color-muted-foreground));
     opacity: 0.7;
   }
-  
+
   /* Default form elements styling - covers elements without specific classes */
   form input,
   form select,
@@ -473,7 +342,7 @@ code, pre, kbd, samp {
     border: 1px solid oklch(var(--color-border));
     border-radius: 0;
   }
-  
+
   .dark form input,
   .dark form select,
   .dark form textarea {
@@ -481,7 +350,7 @@ code, pre, kbd, samp {
     color: oklch(var(--color-foreground));
     border-color: oklch(var(--color-border));
   }
-  
+
   /* Ensure text color is visible in dark mode */
   .dark input,
   .dark textarea,

--- a/packages/app-store/package.json
+++ b/packages/app-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/app-store",
-  "version": "0.2.13-beta.202607221329.f4ae079fb",
+  "version": "0.2.13-beta.202607221520.e50fd77ec",
   "private": false,
   "type": "module",
   "description": "SMART on FHIR app store — manifest discovery, visibility configuration, and registry CRUD. Framework-agnostic.",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/auth",
-  "version": "0.2.13-beta.202607221329.f4ae079fb",
+  "version": "0.2.13-beta.202607221520.e50fd77ec",
   "private": false,
   "type": "module",
   "description": "SMART on FHIR STU 2.2.0 server-side authorization proxy — launch context, session management, token enrichment. Framework-agnostic, IdP-pluggable.",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/cli",
-  "version": "0.2.13-beta.202607221329.f4ae079fb",
+  "version": "0.2.13-beta.202607221520.e50fd77ec",
   "private": false,
   "type": "module",
   "description": "Admin CLI for the proxy-smart SMART on FHIR authorization proxy. Authenticates via Keycloak OAuth (device flow or client_credentials) and drives the admin REST API.",

--- a/packages/elysia-mcp/package.json
+++ b/packages/elysia-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@max-health-inc/elysia-mcp",
-  "version": "0.2.13-beta.202607221329.f4ae079fb",
+  "version": "0.2.13-beta.202607221520.e50fd77ec",
   "private": false,
   "type": "module",
   "description": "Auto-generate MCP tools and resources from Elysia routes via introspection. TypeBox-to-Zod bridge, Streamable HTTP transport, session management.",

--- a/packages/patient-picker/package.json
+++ b/packages/patient-picker/package.json
@@ -3,7 +3,7 @@
   "displayName": "Proxy Smart Patient Picker",
   "description": "Patient selection UI shown during SMART standalone launch when patient context is needed.",
   "private": true,
-  "version": "0.2.13-beta.202607221329.f4ae079fb",
+  "version": "0.2.13-beta.202607221520.e50fd77ec",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5176",

--- a/testing/e2e/package.json
+++ b/testing/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/e2e",
-  "version": "0.2.13-beta.202607221329.f4ae079fb",
+  "version": "0.2.13-beta.202607221520.e50fd77ec",
   "private": true,
   "description": "End-to-end Playwright tests for Proxy Smart apps",
   "scripts": {


### PR DESCRIPTION
## What

The admin UI hand-maintained the Max Health brand tokens in `frontend/ui/src/index.css` (all `:root`/`.dark` colour values plus the `@theme inline` colour map). Those values are owned canonically by **`brandc`** (the org design-language contract, renamed from `@max-network/css` and published to public npm — see max-network/css#2), which `@max-health-inc/shared-ui` also consumes. This PR makes the admin UI consume the same source instead of duplicating it.

- `index.css` now `@import`s `brandc/theme.css` (token values, `light-dark()`, radius 0, flat, the `--maxhealth` emerald) and `brandc/tailwind.css` (utility mapping — `bg-primary`, `text-maxhealth`, `bg-success`/`warning`/`info`).
- `package.json`: depends on `brandc@^0.2.0`.
- Removed the duplicated token blocks; kept only documented app-specific overrides (self-hosted Geist fonts, the multi-hue healthcare chart palette, the larger radius steps the contract doesn't zero, and the app base layer).

Verified: `bun run build` passes; built CSS carries the contract tokens (incl. the new `success`/`warning`/`info`).

## No token needed (resolved)

`brandc` is on **public npm**, and `shared-ui` migrated to it too, so `bun install` needs **no** registry auth — local, CI, or Docker. The lockfile carries zero `@max-network/css` references and the `@max-network` private-registry scope was removed from `bunfig.toml`. The earlier `GH_PACKAGES_TOKEN` requirement is gone; this PR is mergeable with no secret.

## Visual delta

The `--maxhealth` emerald, radius 0, and flat/no-shadow surfaces are unchanged. `--primary`/`--foreground` shift very slightly to the canonical contract shades. Charts keep the app's multi-hue palette via a local override.

## Follow-ups (separate)

- Login-theme consolidation onto `brandc` (the Keycloak login theme still hand-rolls its own `--ps-*` tokens) and per-org brand color — tracked in #838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)