### PR TITLE
feat(branding): per-org brand color — data model, admin UI, patient picker (#838 phases 1-2)

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -160,6 +160,8 @@ export const config = {
     get identifier() { return process.env.BRAND_IDENTIFIER || process.env.BRAND_WEBSITE || process.env.BASE_URL || 'http://localhost:8445' },
     get loginTheme(): string | null { return process.env.BRAND_LOGIN_THEME || null },
     get appStoreUrl(): string | null { return process.env.BRAND_APP_STORE_URL || null },
+    get primaryColor(): string | null { return process.env.BRAND_PRIMARY_COLOR || null },
+    get accentColor(): string | null { return process.env.BRAND_ACCENT_COLOR || null },
   },
 
   ai: {

--- a/backend/src/lib/org-branding.ts
+++ b/backend/src/lib/org-branding.ts
@@ -41,6 +41,8 @@ export function parseOrgBrandAttributes(attrs: Record<string, string[]>): Partia
   if (get('website') !== undefined) result.website = get('website')!
   if (get('logo_url') !== undefined) result.logoUrl = get('logo_url') || null
   if (get('logo_license_url') !== undefined) result.logoLicenseUrl = get('logo_license_url') || null
+  if (get('primary_color') !== undefined) result.primaryColor = get('primary_color') || null
+  if (get('accent_color') !== undefined) result.accentColor = get('accent_color') || null
   if (get('aliases') !== undefined) {
     result.aliases = (get('aliases') || '').split(',').map(s => s.trim()).filter(Boolean)
   }
@@ -91,6 +93,8 @@ export function brandToOrgAttributes(settings: Partial<BrandConfigType>): Record
   if (settings.addressState !== undefined) set('address_state', settings.addressState)
   if (settings.addressPostalCode !== undefined) set('address_postal_code', settings.addressPostalCode)
   if (settings.addressCountry !== undefined) set('address_country', settings.addressCountry)
+  if (settings.primaryColor !== undefined) set('primary_color', settings.primaryColor)
+  if (settings.accentColor !== undefined) set('accent_color', settings.accentColor)
   if (settings.identifier !== undefined) set('identifier', settings.identifier)
 
   return attrs

--- a/backend/src/lib/runtime-config.ts
+++ b/backend/src/lib/runtime-config.ts
@@ -546,6 +546,8 @@ export function getRuntimeBrandConfig(): BrandConfigType {
     identifier: config.brand.identifier,
     loginTheme: config.brand.loginTheme,
     appStoreUrl: config.brand.appStoreUrl,
+    primaryColor: config.brand.primaryColor,
+    accentColor: config.brand.accentColor,
   }
 
   const merged = !brandOverrides ? envDefaults : { ...envDefaults, ...brandOverrides }

--- a/backend/src/routes/auth/oauth.ts
+++ b/backend/src/routes/auth/oauth.ts
@@ -13,6 +13,9 @@ import { hasClientAssertion, translateClientAssertion, ClientAssertionError } fr
 import { kcUnavailablePage, authErrorPage } from './smart-templates'
 import { autoResolvePatient } from '@/lib/kc-session-resolver'
 import { smartProxyConfig, smartStore, keycloakAdapter, smartLogger } from './smart-proxy-setup'
+import { getAdminClient } from '@/lib/kc-admin-factory'
+import { getOrgBranding } from '@/lib/org-branding'
+import { getAttr } from '@/lib/smart-client-enrichment'
 import {
   handleAuthorize,
   handleCallback,
@@ -359,6 +362,55 @@ export const oauthRoutes = new Elysia({ tags: ['authentication'] })
     }
   }, {
     detail: { summary: 'Patient Search (Picker)', description: 'Session-validated Patient search for the patient picker SPA. Proxies to upstream FHIR server without requiring a Bearer token.', tags: ['authentication'] }
+  })
+
+  // ── Brand context (session-validated, for patient picker theming) ─────
+  // Resolves the brand COLOUR for the launch so the picker can theme itself to
+  // the launching organization. Starts from the global brand, then applies the
+  // launching client's org override when resolvable. UI-theming only — this is
+  // NOT the SMART User-access Brand (no logo/portal/endpoints here).
+  .get('/brand-context', async ({ query, set }) => {
+    const sessionKey = query.session as string | undefined
+    if (!sessionKey) {
+      set.status = 400
+      return { error: 'invalid_request', error_description: 'Missing session parameter' }
+    }
+    const session = smartStore.get(sessionKey)
+    if (!session) {
+      set.status = 401
+      return { error: 'session_expired', error_description: 'Session expired. Please restart the authorization flow.' }
+    }
+
+    // Global brand colour is the default.
+    const brand: { primaryColor: string | null; accentColor: string | null } = {
+      primaryColor: config.brand.primaryColor,
+      accentColor: config.brand.accentColor,
+    }
+
+    // Per-org override: session client → its organization → org brand colour.
+    // Best-effort and non-fatal; falls back to the global brand on any failure.
+    try {
+      const clientId = (session as { clientId?: string }).clientId
+      const admin = clientId ? await getAdminClient() : null
+      if (admin && clientId) {
+        const clients = await admin.clients.find({ clientId })
+        const orgIds = getAttr(clients[0]?.attributes, 'organization_ids')?.split(',').filter(Boolean)
+        if (orgIds && orgIds.length > 0) {
+          const orgBrand = await getOrgBranding(admin, orgIds[0])
+          if (orgBrand.primaryColor) brand.primaryColor = orgBrand.primaryColor
+          if (orgBrand.accentColor) brand.accentColor = orgBrand.accentColor
+        }
+      }
+    } catch (err) {
+      logger.auth.debug('brand-context: per-org resolution failed, using global brand', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+
+    set.headers['Cache-Control'] = 'no-store'
+    return brand
+  }, {
+    detail: { summary: 'Brand Context (Picker)', description: 'Session-validated brand colour for theming the patient picker to the launching organization.', tags: ['authentication'] }
   })
 
   // ── Login redirect ────────────────────────────────────────────────────

--- a/backend/src/schemas/admin/branding.ts
+++ b/backend/src/schemas/admin/branding.ts
@@ -44,6 +44,11 @@ export const BrandConfig = t.Object({
   identifier: t.String({ description: 'Brand identifier URI (typically the brand website URL)' }),
   loginTheme: t.Union([t.String(), t.Null()], { description: 'Keycloak login theme name (e.g. keycloak, keycloak.v2)' }),
   appStoreUrl: t.Union([t.String(), t.Null()], { description: 'External App Store URL (e.g. https://apps.example.com). When set, /apps redirects here instead of serving locally.' }),
+  // UI-theming extension (NOT part of the SMART User-access Brand / branding.json).
+  // A CSS colour (hex or any CSS <color>) used to theme auth surfaces (login, patient
+  // picker) via a runtime --primary/--maxhealth override on the brandc contract.
+  primaryColor: t.Optional(t.Union([t.String(), t.Null()], { description: 'Brand primary colour (CSS <color>, e.g. #00d294) for theming auth surfaces. Not published in branding.json.' })),
+  accentColor: t.Optional(t.Union([t.String(), t.Null()], { description: 'Optional brand accent colour (CSS <color>). Not published in branding.json.' })),
 }, { title: 'BrandConfig' })
 
 export type BrandConfigType = Omit<Static<typeof BrandConfig>, 'category'> & { category: BrandCategoryType }

--- a/config/eslint/package.json
+++ b/config/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/eslint-config",
-  "version": "0.2.13-beta.202607221329.f4ae079fb",
+  "version": "0.2.13-beta.202607221520.e50fd77ec",
   "private": true,
   "type": "module",
   "exports": {

--- a/frontend/smart-dicom-template/package.json
+++ b/frontend/smart-dicom-template/package.json
@@ -3,7 +3,7 @@
   "displayName": "SMART DICOM Algorithm Template",
   "description": "Starter kit for building SMART on FHIR imaging algorithm apps. Clone, implement your algorithm in src/algorithm.ts, and deploy as a SMART app.",
   "private": true,
-  "version": "0.2.13-beta.202607221329.f4ae079fb",
+  "version": "0.2.13-beta.202607221520.e50fd77ec",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5180",

--- a/frontend/ui/package.json
+++ b/frontend/ui/package.json
@@ -3,7 +3,7 @@
   "displayName": "Proxy Smart Admin UI",
   "description": "A web-based administration interface for managing healthcare applications and resources via Proxy Smart.",
   "private": true,
-  "version": "0.2.13-beta.202607221329.f4ae079fb",
+  "version": "0.2.13-beta.202607221520.e50fd77ec",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/ui/src/components/BrandSettings.tsx
+++ b/frontend/ui/src/components/BrandSettings.tsx
@@ -13,6 +13,7 @@ import {
   Image,
   MapPin,
   ExternalLink,
+  Palette,
   Paintbrush,
 } from 'lucide-react';
 import { config } from '@/config';
@@ -42,6 +43,8 @@ interface BrandConfig {
   identifier: string;
   loginTheme: string | null;
   appStoreUrl: string | null;
+  primaryColor?: string | null;
+  accentColor?: string | null;
 }
 
 const DEFAULT_BRAND: BrandConfig = {
@@ -63,6 +66,8 @@ const DEFAULT_BRAND: BrandConfig = {
   identifier: '',
   loginTheme: null,
   appStoreUrl: null,
+  primaryColor: null,
+  accentColor: null,
 };
 
 const CATEGORY_OPTIONS = UserAccessCategoryValueSetConcepts.map(c => ({
@@ -375,6 +380,31 @@ export function BrandSettings() {
               />
               <p className="text-xs text-muted-foreground">
                 {t('External App Store URL. When set, /apps redirects here instead of serving the built-in App Store.')}
+              </p>
+            </div>
+
+            {/* Brand color (theming) */}
+            <div className="space-y-2">
+              <Label className="flex items-center gap-2">
+                <Palette className="w-3.5 h-3.5" />
+                {t('Brand Color')}
+              </Label>
+              <div className="flex items-center gap-2">
+                <input
+                  type="color"
+                  aria-label={t('Brand Color')}
+                  value={brand.primaryColor || '#00d294'}
+                  onChange={(e) => updateField('primaryColor', e.target.value)}
+                  className="h-9 w-12 shrink-0 cursor-pointer rounded border border-border bg-transparent p-1"
+                />
+                <Input
+                  value={brand.primaryColor || ''}
+                  onChange={(e) => updateField('primaryColor', e.target.value || null)}
+                  placeholder="#00d294"
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {t('Primary colour used to theme the login page and patient picker for this brand. Any CSS colour (e.g. #00d294). Not published in branding.json.')}
               </p>
             </div>
           </CardContent>

--- a/packages/app-store/package.json
+++ b/packages/app-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/app-store",
-  "version": "0.2.13-beta.202607221329.f4ae079fb",
+  "version": "0.2.13-beta.202607221520.e50fd77ec",
   "private": false,
   "type": "module",
   "description": "SMART on FHIR app store — manifest discovery, visibility configuration, and registry CRUD. Framework-agnostic.",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/auth",
-  "version": "0.2.13-beta.202607221329.f4ae079fb",
+  "version": "0.2.13-beta.202607221520.e50fd77ec",
   "private": false,
   "type": "module",
   "description": "SMART on FHIR STU 2.2.0 server-side authorization proxy — launch context, session management, token enrichment. Framework-agnostic, IdP-pluggable.",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/cli",
-  "version": "0.2.13-beta.202607221329.f4ae079fb",
+  "version": "0.2.13-beta.202607221520.e50fd77ec",
   "private": false,
   "type": "module",
   "description": "Admin CLI for the proxy-smart SMART on FHIR authorization proxy. Authenticates via Keycloak OAuth (device flow or client_credentials) and drives the admin REST API.",

--- a/packages/elysia-mcp/package.json
+++ b/packages/elysia-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@max-health-inc/elysia-mcp",
-  "version": "0.2.13-beta.202607221329.f4ae079fb",
+  "version": "0.2.13-beta.202607221520.e50fd77ec",
   "private": false,
   "type": "module",
   "description": "Auto-generate MCP tools and resources from Elysia routes via introspection. TypeBox-to-Zod bridge, Streamable HTTP transport, session management.",

--- a/packages/patient-picker/package.json
+++ b/packages/patient-picker/package.json
@@ -3,7 +3,7 @@
   "displayName": "Proxy Smart Patient Picker",
   "description": "Patient selection UI shown during SMART standalone launch when patient context is needed.",
   "private": true,
-  "version": "0.2.13-beta.202607221329.f4ae079fb",
+  "version": "0.2.13-beta.202607221520.e50fd77ec",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5176",

--- a/packages/patient-picker/src/App.tsx
+++ b/packages/patient-picker/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useEffect } from "react"
 import { getPickerParams, getPickerError } from "@/lib/picker-params"
-import { submitPatientSelection } from "@/lib/api-client"
+import { submitPatientSelection, fetchBrandContext } from "@/lib/api-client"
 import { PatientList } from "@/components/PatientList"
 import { formatHumanName, AppHeader, Button, onAuthError, useScene } from "@proxy-smart/shared-ui"
 import { UserSearch, AlertTriangle, CheckCircle2, LogIn } from "lucide-react"
@@ -20,6 +20,17 @@ export default function App() {
     onAuthError((message) => {
       setAuthError(message)
       setTimeout(() => { window.location.href = window.location.origin }, 4000)
+    })
+  }, [])
+
+  // Theme the picker to the launching organization's brand colour (best-effort).
+  // Overrides the brandc contract's --primary/--maxhealth for this launch only.
+  useEffect(() => {
+    fetchBrandContext().then((brand) => {
+      if (!brand?.primaryColor) return
+      const root = document.documentElement
+      root.style.setProperty("--primary", brand.primaryColor)
+      root.style.setProperty("--maxhealth", brand.primaryColor)
     })
   }, [])
 

--- a/packages/patient-picker/src/lib/api-client.ts
+++ b/packages/patient-picker/src/lib/api-client.ts
@@ -66,6 +66,32 @@ interface PatientSelectResult {
   redirect_url: string
 }
 
+// ── Brand Context API ─────────────────────────────────────────────────────
+
+interface BrandContext {
+  primaryColor: string | null
+  accentColor: string | null
+}
+
+/**
+ * Best-effort brand colour for the current launch, used to theme the picker to
+ * the launching organization. Never throws — theming is optional, so any
+ * failure just leaves the default brand in place.
+ */
+export async function fetchBrandContext(): Promise<BrandContext | null> {
+  const pickerParams = getPickerParams()
+  if (!pickerParams?.session) return null
+  try {
+    const url = new URL("/auth/brand-context", window.location.origin)
+    url.searchParams.set("session", pickerParams.session)
+    const res = await fetch(url.href)
+    if (!res.ok) return null
+    return (await res.json()) as BrandContext
+  } catch {
+    return null
+  }
+}
+
 export async function submitPatientSelection(session: string, code: string, patientId: string): Promise<string> {
   const data = await apiFetch<PatientSelectResult>("/auth/patient-select", {
     method: "POST",

--- a/testing/e2e/package.json
+++ b/testing/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/e2e",
-  "version": "0.2.13-beta.202607221329.f4ae079fb",
+  "version": "0.2.13-beta.202607221520.e50fd77ec",
   "private": true,
   "description": "End-to-end Playwright tests for Proxy Smart apps",
   "scripts": {


### PR DESCRIPTION
Phases 1-2 of #838. An organization's brand **color** now themes the **patient picker** for its launches. No SMART app is affected — this only themes the proxy's own picker screen.

## Phase 1 — data model + admin UI
- **Schema**: optional `primaryColor` / `accentColor` (nullable CSS `<color>`) on `BrandConfig`, flowing through `OrgBrandConfig` (partial) for per-org overrides.
- **Config**: `BRAND_PRIMARY_COLOR` / `BRAND_ACCENT_COLOR` env defaults; included in the assembled runtime brand.
- **Org branding**: (de)serialize `primary_color` / `accent_color` Keycloak organization attributes (per-org overrides persist on the KC org).
- **Admin UI** (`BrandSettings.tsx`): color picker + CSS-color text input.

## Phase 2 — patient picker rendering
- **Backend**: `GET /auth/brand-context` (session-validated, no bearer) resolves the brand color for the launch — global brand, overridden by the session client's organization when resolvable. Best-effort and non-fatal (global fallback).
- **Picker**: `fetchBrandContext()` + a mount effect set `--primary`/`--maxhealth` on the document root, retinting the picker (which already renders on the brandc contract via `shared-ui/theme.css`). Any failure leaves the default brand.

## Explicitly not included
- **Not** part of the SMART User-access Brand; **not** emitted to `branding.json`.
- Launched SMART apps keep their own designs.

## Follow-up (tracked in #838)
- **Phase 3** — Keycloak login page: needs the login theme consolidated onto `brandc` first (it still hand-rolls its own `--ps-*` tokens), then per-org injection (a Keycloak-theming design decision).

Backend + patient-picker typecheck and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)